### PR TITLE
Supports schemas defined in the local file using the $ref property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 clover.xml
+.idea

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ use JSONSchemaFaker\Faker;
 
 $schema = json_decode(file_get_contents('./schema.json'));
 $dummy = Faker::fake($schema);
+
+or 
+
+$dummy = Faker::fake(new SplFileInfo('./schema.json')); // to support external schema file ($ref)
+
 ```
 
 ## Contribution

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "fzaninotto/faker": "^1.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "ext-json": "*",
+        "ext-mbstring": "*",
         "fzaninotto/faker": "^1.7"
     },
     "require-dev": {

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -52,9 +52,10 @@ class Faker
     public function generate($schema, \stdClass $parentSchema = null)
     {
         if ($schema instanceof \SplFileInfo) {
-            $path = $schema->getFileInfo()->getRealPath();
+            $path = $schema->getFileInfo()->getPath();
+            $file = $schema->getRealPath();
             $this->schemaDir = $path;
-            $schema = json_decode(file_get_contents($path));
+            $schema = json_decode(file_get_contents($file));
         }
         if (! $schema instanceof \stdClass) {
             throw new \InvalidArgumentException(gettype($schema));

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -50,6 +50,9 @@ class Faker
         if (property_exists($schema, '$ref')) {
             return $this->ref($schema, $parentSchems);
         }
+        if (! isset($schema->type)) {
+            throw new \Exception("No Type");
+        }
         $type = is_array($schema->type) ? Base::randomElement($schema->type) : $schema->type;
 
         if (isset($schema->enum)) {

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -229,7 +229,7 @@ class Faker
         if (substr($path, 0, 1) === '#') {
             return $this->embedded($parentSchema, $path);
         }
-        return $this->linkedJson($parentSchema, $path);
+        return $this->linkedJson($path, $parentSchema);
     }
 
     private function embedded(\stdClass $parentSchema, string $path)
@@ -244,7 +244,7 @@ class Faker
         return $defFake;
     }
 
-    private function linkedJson(\stdClass $parentSchema, string $path)
+    private function linkedJson(string $path, \stdClass $parentSchema = null)
     {
         $jsonPath = sprintf('%s/%s', $this->schemaDir, str_replace('./', '', $path));
         if (!file_exists($jsonPath)) {

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -24,11 +24,6 @@ class Faker
      */
     private $schemaDir;
 
-    public function __construct(string $schemaDir = '')
-    {
-        $this->schemaDir = $schemaDir;
-    }
-
     /**
      * Create dummy data with JSON schema
      *

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -44,13 +44,18 @@ class Faker
     /**
      * Create dummy data with JSON schema
      *
-     * @param  \stdClass $schema Data structure writen in JSON Schema
+     * @param  \SplFileInfo|\stdClass $schema Data structure writen in JSON Schema
      * @param \stdClass $parentSchema parent schema when it is subschema
      * @return mixed dummy data
      * @throws \Exception Throw when unsupported type specified
      */
-    public function generate(\stdClass $schema, \stdClass $parentSchema = null)
+    public function generate($schema, \stdClass $parentSchema = null)
     {
+        if ($schema instanceof \SplFileInfo) {
+            $path = $schema->getFileInfo()->getRealPath();
+            $this->schemaDir = $path;
+            $schema = json_decode(file_get_contents($path));
+        }
         $schema = resolveOf($schema);
         $fakers = $this->getFakers();
 

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -259,9 +259,8 @@ class Faker
             return $this->linkedDefinedSchema($jsonPath);
         }
         $refJson = json_decode(file_get_contents($jsonPath));
-        $fake = $this->generate($refJson, $parentSchema);
 
-        return $fake;
+        return $this->generate($refJson, $parentSchema);
     }
 
     private function linkedDefinedSchema(string $jsonPath)
@@ -276,8 +275,7 @@ class Faker
             throw new \InvalidArgumentException($jsonPath);
         }
         $json = json_decode(file_get_contents($schemaFile));
-        $fake = $this->embedded($json, $path);
 
-        return $fake;
+        return $this->embedded($json, $path);
     }
 }

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -246,12 +246,10 @@ class Faker
     {
         $paths = explode('/', substr($path, 2));
         $prop = $parentSchema;
-        foreach ($paths as $path) {
-            $prop = $prop->{$path};
+        foreach ($paths as $schemaPath) {
+            $prop = $prop->{$schemaPath};
         }
-        $defFake = $this->generate($prop);
-
-        return $defFake;
+        return $this->generate($prop);
     }
 
     private function linkedJson(string $path, \stdClass $parentSchema = null)

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -56,6 +56,9 @@ class Faker
             $this->schemaDir = $path;
             $schema = json_decode(file_get_contents($path));
         }
+        if (! $schema instanceof \stdClass) {
+            throw new \InvalidArgumentException(gettype($schema));
+        }
         $schema = resolveOf($schema);
         $fakers = $this->getFakers();
 

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -236,7 +236,7 @@ class Faker
     private function ref(\stdClass $schema, \stdClass $parentSchema = null)
     {
         $path = (string) $schema->{'$ref'};
-        if (substr($path, 0, 1) === '#') {
+        if ($path[0] === '#' && $parentSchema instanceof \stdClass) {
             return $this->embedded($parentSchema, $path);
         }
         return $this->linkedJson($path, $parentSchema);

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -39,16 +39,17 @@ class Faker
      * Create dummy data with JSON schema
      *
      * @param  \stdClass $schema Data structure writen in JSON Schema
+     * @param \stdClass $parentSchema parent schema when it is subschema
      * @return mixed dummy data
      * @throws \Exception Throw when unsupported type specified
      */
-    public function generate(\stdClass $schema, \stdClass $parentSchems = null)
+    public function generate(\stdClass $schema, \stdClass $parentSchema = null)
     {
         $schema = resolveOf($schema);
         $fakers = $this->getFakers();
 
         if (property_exists($schema, '$ref')) {
-            return $this->ref($schema, $parentSchems);
+            return $this->ref($schema, $parentSchema);
         }
         if (! isset($schema->type)) {
             throw new \Exception("No Type");
@@ -147,6 +148,9 @@ class Faker
         } else {
             $min = get($schema, 'minLength', 1);
             $max = get($schema, 'maxLength', max(5, $min + 1));
+            if ($max < 5) {
+                return substr(Lorem::text(5), 0, $max);
+            }
             $lorem = Lorem::text($max);
 
             if (mb_strlen($lorem) < $min) {

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -7,6 +7,7 @@
 
 namespace JSONSchemaFaker;
 
+use function dirname;
 use function explode;
 use Faker\Provider\Base;
 use Faker\Provider\Lorem;
@@ -32,10 +33,10 @@ class Faker
      * Create dummy data with JSON schema
      *
      * @see    http://json-schema.org
-     * @param  \stdClass $schema Data structure writen in JSON Schema
+     * @param  \SplFileInfo|\stdClass $schema Data structure writen in JSON Schema
      * @return mixed dummy data
      */
-    public static function fake(\stdClass $schema)
+    public static function fake($schema)
     {
         $faker = new static();
         return $faker->generate($schema);
@@ -52,9 +53,8 @@ class Faker
     public function generate($schema, \stdClass $parentSchema = null)
     {
         if ($schema instanceof \SplFileInfo) {
-            $path = $schema->getFileInfo()->getPath();
             $file = $schema->getRealPath();
-            $this->schemaDir = $path;
+            $this->schemaDir = dirname($file);
             $schema = json_decode(file_get_contents($file));
         }
         if (! $schema instanceof \stdClass) {

--- a/src/Faker.php
+++ b/src/Faker.php
@@ -7,13 +7,10 @@
 
 namespace JSONSchemaFaker;
 
-use function dirname;
-use function explode;
 use Faker\Provider\Base;
 use Faker\Provider\Lorem;
-use function file_exists;
+use function dirname;
 use function file_get_contents;
-use function implode;
 use function json_decode;
 use function substr;
 

--- a/src/Ref.php
+++ b/src/Ref.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * JSON Schema faker
+ *
+ * @see https://github.com/Leko/php-json-schema-faker
+ */
+
+namespace JSONSchemaFaker;
+
+class Ref
+{
+    /**
+     * @var Faker
+     */
+    private $faker;
+
+    /**
+     * @var string
+     */
+    private $schemaDir;
+
+    public function __construct(Faker $faker, $schemaDir)
+    {
+        $this->faker = $faker;
+        $this->schemaDir = $schemaDir;
+    }
+
+    public function __invoke(\stdClass $schema, \stdClass $parentSchema = null)
+    {
+        $path = (string) $schema->{'$ref'};
+        if ($path[0] === '#' && $parentSchema instanceof \stdClass) {
+            return $this->inlineRef($parentSchema, $path);
+        }
+        return $this->externalRef($path, $parentSchema);
+    }
+
+    private function inlineRef(\stdClass $parentSchema, string $path)
+    {
+        $paths = explode('/', substr($path, 2));
+        $prop = $parentSchema;
+        foreach ($paths as $schemaPath) {
+            $prop = $prop->{$schemaPath};
+        }
+        return $this->faker->generate($prop);
+    }
+
+    private function externalRef(string $path, \stdClass $parentSchema = null)
+    {
+        $jsonPath = sprintf('%s/%s', $this->schemaDir, str_replace('./', '', $path));
+        if (! file_exists($jsonPath)) {
+            return $this->inlineRefInExternalRef($jsonPath);
+        }
+        $refJson = json_decode(file_get_contents($jsonPath));
+
+        return $this->faker->generate($refJson, $parentSchema);
+    }
+
+    private function inlineRefInExternalRef(string $jsonPath)
+    {
+        $paths = explode('#', $jsonPath);
+        if (count($paths) !== 2) {
+            throw new \RuntimeException("JSON file not exits:{$jsonPath}");
+        }
+        $schemaFile = $paths[0];
+        $path = '.' . $paths[1];
+        if (! file_exists($schemaFile)) {
+            throw new \RuntimeException("JSON file not exits:{$jsonPath}");
+        }
+        $json = json_decode(file_get_contents($schemaFile));
+
+        return $this->inlineRef($json, $path);
+    }
+}

--- a/src/Ref.php
+++ b/src/Ref.php
@@ -50,9 +50,8 @@ class Ref
         if (! file_exists($jsonPath)) {
             return $this->inlineRefInExternalRef($jsonPath);
         }
-        $refJson = json_decode(file_get_contents($jsonPath));
 
-        return $this->faker->generate($refJson, $parentSchema);
+        return $this->faker->generate(new \SplFileInfo($jsonPath), $parentSchema);
     }
 
     private function inlineRefInExternalRef(string $jsonPath)

--- a/src/helper.php
+++ b/src/helper.php
@@ -9,9 +9,9 @@ namespace JSONSchemaFaker;
 
 use Faker\Factory;
 use Faker\Provider\Base;
-use Faker\Provider\Lorem;
 use Faker\Provider\DateTime;
 use Faker\Provider\Internet;
+use Faker\Provider\Lorem;
 
 /**
  * Get value without E_NOTICE

--- a/test/FakerTest.php
+++ b/test/FakerTest.php
@@ -22,7 +22,7 @@ class FakerTest extends TestCase
     }
 
     /**
-     * @dataProvider getTypes
+     * @dataProvider getTypesAndFile
      */
     public function testFakeFromFile($type)
     {
@@ -53,6 +53,21 @@ class FakerTest extends TestCase
             ['object'],
             ['combining'],
             ['ref_inline']
+        ];
+    }
+
+    public function getTypesAndFile()
+    {
+        return [
+            ['boolean'],
+            ['null'],
+            ['integer'],
+            ['number'],
+            ['string'],
+            ['array'],
+            ['object'],
+            ['combining'],
+            ['ref_file']
         ];
     }
 

--- a/test/FakerTest.php
+++ b/test/FakerTest.php
@@ -51,7 +51,8 @@ class FakerTest extends TestCase
             ['string'],
             ['array'],
             ['object'],
-            ['combining']
+            ['combining'],
+            ['ref_inline']
         ];
     }
 

--- a/test/FakerTest.php
+++ b/test/FakerTest.php
@@ -21,6 +21,20 @@ class FakerTest extends TestCase
         $this->assertTrue($validator->isValid(), json_encode($validator->getErrors(), JSON_PRETTY_PRINT));
     }
 
+    /**
+     * @dataProvider getTypes
+     */
+    public function testFakeFromFIle($type)
+    {
+        $schema = $this->getFile($type);
+        $validator = new Validator();
+
+        $actual = (new Faker)->generate(new \SplFileInfo($schema));
+        $validator->check($actual, $schema);
+
+        $this->assertTrue($validator->isValid(), json_encode($validator->getErrors(), JSON_PRETTY_PRINT));
+    }
+
     public function getTypes()
     {
         return [

--- a/test/FakerTest.php
+++ b/test/FakerTest.php
@@ -67,7 +67,8 @@ class FakerTest extends TestCase
             ['array'],
             ['object'],
             ['combining'],
-            ['ref_file']
+            ['ref_file'],
+            ['ref_file_double']
         ];
     }
 

--- a/test/FakerTest.php
+++ b/test/FakerTest.php
@@ -24,7 +24,7 @@ class FakerTest extends TestCase
     /**
      * @dataProvider getTypes
      */
-    public function testFakeFromFIle($type)
+    public function testFakeFromFile($type)
     {
         $schema = $this->getFile($type);
         $validator = new Validator();
@@ -33,6 +33,12 @@ class FakerTest extends TestCase
         $validator->check($actual, $schema);
 
         $this->assertTrue($validator->isValid(), json_encode($validator->getErrors(), JSON_PRETTY_PRINT));
+    }
+
+    public function testGenerateInvalidParameter()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        (new Faker)->generate(null);
     }
 
     public function getTypes()

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -9,6 +9,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
         return json_decode(file_get_contents(__DIR__ . "/fixture/{$name}.json"));
     }
 
+    protected function getFile($name)
+    {
+        return __DIR__ . "/fixture/{$name}.json";
+    }
+
     protected function callInternalMethod($instance, $method, array $args = [])
     {
         $ref = new \ReflectionMethod(get_class($instance), $method);

--- a/test/fixture/def/ref.json
+++ b/test/fixture/def/ref.json
@@ -5,7 +5,7 @@
   ],
   "properties": {
     "typeOnly": {
-      "type": "array"
+      "$ref": "./typeOnly.json"
     }
   }
 }

--- a/test/fixture/def/typeAndMaxItems.json
+++ b/test/fixture/def/typeAndMaxItems.json
@@ -1,7 +1,12 @@
 {
   "type": "object",
-  "typeAndMaxItems": {
-    "type": "array",
-    "maxItems": 10
+  "required": [
+    "typeAndMaxItems"
+  ],
+  "properties": {
+    "typeAndMaxItems": {
+      "type": "array",
+      "maxItems": 10
+    }
   }
 }

--- a/test/fixture/def/typeAndMaxItems.json
+++ b/test/fixture/def/typeAndMaxItems.json
@@ -1,0 +1,7 @@
+{
+  "type": "object",
+  "typeAndMaxItems": {
+    "type": "array",
+    "maxItems": 10
+  }
+}

--- a/test/fixture/def/typeOnly.json
+++ b/test/fixture/def/typeOnly.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "typeOnly": {
+    "type": "array"
+  }
+}

--- a/test/fixture/ref_file.json
+++ b/test/fixture/ref_file.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "required": [
+    "typeOnly",
+    "typeAndMinItems",
+    "typeAndMaxItems",
+    "typeAndMinItems",
+    "typeAndMultipleItems"
+  ],
+  "properties": {
+    "typeOnly": {
+      "$ref": "./def/typeOnly.json"
+    },
+    "typeAndMaxItems": {
+      "$ref": "./def/typeAndMaxItems.json"
+    }
+  }
+}

--- a/test/fixture/ref_file.json
+++ b/test/fixture/ref_file.json
@@ -2,10 +2,7 @@
   "type": "object",
   "required": [
     "typeOnly",
-    "typeAndMinItems",
-    "typeAndMaxItems",
-    "typeAndMinItems",
-    "typeAndMultipleItems"
+    "typeAndMinItems"
   ],
   "properties": {
     "typeOnly": {

--- a/test/fixture/ref_file_double.json
+++ b/test/fixture/ref_file_double.json
@@ -5,7 +5,7 @@
   ],
   "properties": {
     "typeOnly": {
-      "type": "array"
+      "$ref": "./def/ref.json"
     }
   }
 }

--- a/test/fixture/ref_inline.json
+++ b/test/fixture/ref_inline.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "required": [
+    "typeOnly",
+    "typeAndMinItems",
+    "typeAndMaxItems",
+    "typeAndMinItems",
+    "typeAndMultipleItems"
+  ],
+  "properties": {
+    "typeOnly": {
+      "$ref": "#/definitions/typeOnly"
+    },
+    "typeAndMaxItems": {
+      "$ref": "#/definitions/typeAndMaxItems"
+    },
+    "typeAndMinItems": {
+      "$ref": "#/definitions/typeAndMinItems"
+    },
+    "typeAndMultipleItems": {
+      "$ref": "#/definitions/typeAndMultipleItems"
+    }
+  },
+  "definitions": {
+    "typeOnly": {
+      "type": "array"
+    },
+    "typeAndMaxItems": {
+      "type": "array",
+      "maxItems": 10
+    },
+    "typeAndMinItems": {
+      "type": "array",
+      "minItems": 10,
+      "maxItems": 10
+    },
+    "typeAndMultipleItems": {
+      "type": "array",
+      "items": [{
+        "type": "integer"
+      }, {
+        "type": "string"
+      }]
+    }
+  }
+}


### PR DESCRIPTION
This PR supports reference schemas defined in the local file or external files using the $ref property.

We need to pass the local file path to get local schema file by the relative path. To do so,  ` Faker::fake` method accepts not only `stdClaas` JSON object but also `SplFileInfo` JSON file path.

```php
$schema = json_decode(file_get_contents('./schema.json'));
$dummy = Faker::fake($schema);
```
or
```php
$dummy = Faker::fake(new SplFileInfo('./schema.json')); 
```

Both are valid call. No BC break.